### PR TITLE
fix: doc test

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -11,6 +11,7 @@
 /// Then, in your test, use the `verso_test!` macro to run your tests. The tests must be functions that take an `EventLoopWindowTarget`.
 ///
 /// ```rust
+/// use verso::verso_test;
 /// use verso::winit::event_loop::EventLoopWindowTarget;
 ///
 /// fn my_test(elwt: &EventLoopWindowTarget<()>) {


### PR DESCRIPTION
```
---- src/test.rs - test::verso_test (line 13) stdout ----
error: cannot find macro `verso_test` in this scope
  --> src/test.rs:25:1
   |
15 | verso_test!(my_test, other_test);
   | ^^^^^^^^^^
   |
help: consider importing this macro
   |
2  + use verso::verso_test;
   |
```