### PR TITLE
ci: use `macos-latest` to build aarch64 platform

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,7 +159,7 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - { target: aarch64-apple-darwin, os: macos-14 }
+          - { target: aarch64-apple-darwin, os: macos-latest }
           - { target: x86_64-apple-darwin, os: macos-13 }
     runs-on: ${{ matrix.platform.os }}
     env:


### PR DESCRIPTION
https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/

`macos-latest` has pointed to `macos-14`